### PR TITLE
fix: rename config flow handler class to ConfigFlow for proper registration

### DIFF
--- a/custom_components/everhome/config_flow.py
+++ b/custom_components/everhome/config_flow.py
@@ -14,10 +14,9 @@ from .const import API_BASE_URL, API_DEVICE_URL, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-class EverhomeFlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler):
+class ConfigFlow(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN):
     """Config flow to handle Everhome OAuth2 authentication."""
 
-    DOMAIN = DOMAIN
     VERSION = 1
 
     # Allow multiple config entries


### PR DESCRIPTION
Fixes the 'Flow handler not found for entry Everhome' error by renaming the config flow handler class from EverhomeFlowHandler to ConfigFlow, which is the expected name by Home Assistant.

Also updates to use modern domain parameter syntax instead of DOMAIN class attribute.

This is a critical bug fix that prevents the integration from working properly when users try to access config entries.